### PR TITLE
fix RiverTile class missing in MahjongPyWrapper

### DIFF
--- a/MahjongPyWrapper/MahjongPy.cpp
+++ b/MahjongPyWrapper/MahjongPy.cpp
@@ -87,6 +87,13 @@ PYBIND11_MODULE(MahjongPyWrapper, m)
 		// .def("to_simple_string", &Tile::to_string)
 		;
 
+	py::class_<RiverTile>(m, "RiverTile")
+		.def_readonly("tile", &RiverTile::tile)
+		.def_readonly("remain", &RiverTile::remain)
+		.def_readonly("riichi", &RiverTile::riichi)
+		.def_readonly("fromhand", &RiverTile::fromhand)
+		;
+		
 	m.def("TileToString", [](const Tile *tile) {return py::bytes(tile->to_string()); });
 
 	py::class_<River>(m, "River")


### PR DESCRIPTION
When I try to create a function in `env_pymahjong.py` line 420 like:
```python
    def get_players_info(self):
        info = []
        for playerID in range(4):
            player_info = {}
            player_info['score'] = self.env.t.players[playerID].score
            player_info['riichi'] = self.env.t.players[playerID].riichi
            player_info['menchin'] = self.env.t.players[playerID].menchin
            player_info['oya'] = self.env.t.players[playerID].oya
            player_info['wind'] = self.env.t.players[playerID].wind
            player_info['ippatsu'] = self.env.t.players[playerID].ippatsu
            player_info['hand'] = [tile.tile for tile in self.env.t.players[playerID].hand]
            player_info['furiten'] = self.env.t.players[playerID].is_furiten()

            # error occurs
            player_info['river'] = [t.tile.tile for t in self.env.t.players[playerID].get_river().river]
```
An error occures that:
```
Unable to convert function return value to a Python type! The signature was
        (self: MahjongPyWrapper.River) -> List[mahjong::RiverTile]
```
Because class RiverTile is undefined in pybind.  So you need to add it.