### PR TITLE
fix(paipu): broken Tenhou paipu URLs (score deltas, AGARI JSON format, ron/tsumo classification)

### DIFF
--- a/pymahjong/paipu_recorder.py
+++ b/pymahjong/paipu_recorder.py
@@ -508,11 +508,18 @@ class TenhouPaipuRecorder:
     def _result_element(self, table, gl) -> ET.Element:
         result = gl.result
         rt = result.result_type
-        # ``gl.result`` is sometimes left uninitialized (rt = Error / -1)
-        # when the game ends via an unusual terminal path under random
-        # play.  Fall back to ``t.get_scores()`` for finals so the
-        # recorded paipu always reflects what the engine actually decided.
-        final_scores = list(table.get_scores())
+        # Prefer ``result.score`` (engine-computed per-hand final scores,
+        # populated by GameResult.cpp for every ron / tsumo / ryuukyoku /
+        # nagashi-mangan path).  ``table.get_scores()`` reflects the
+        # player counters which, in single-hand V4MultiAgentEnv use, may
+        # still be at the pre-agari snapshot (with only the riichi-stick
+        # deduction applied), so deltas computed from it are wrong for
+        # agari hands.  Fall back to ``t.get_scores()`` only when the
+        # result struct is uninitialized (rt = Error / -1).
+        if int(rt) >= 0:
+            final_scores = [int(s) for s in result.score]
+        else:
+            final_scores = list(table.get_scores())
         score_changes = [
             (final_scores[i] - gl.start_scores[i]) // 100 for i in range(4)
         ]
@@ -749,11 +756,38 @@ def _replay_one_hand_from_xml(
             break
 
         if tag in ("AGARI", "RYUUKYOKU"):
-            # Drain any final response-phase passes and any forced ryuukyoku.
-            for _ in range(8):
+            # Drain pending response phases and trigger the recorded
+            # terminal action (ron / tsumo / forced ryuukyoku) so the
+            # engine actually computes ``result.score``.
+            target_winner = -1
+            target_fromwho = -1
+            is_tsumo = False
+            if tag == "AGARI":
+                target_winner = int(sib.get("who"))
+                target_fromwho = int(sib.get("fromWho"))
+                is_tsumo = (target_winner == target_fromwho)
+            for _ in range(12):
                 if int(t.get_phase()) == GAME_OVER:
                     break
                 phase = int(t.get_phase())
+                if tag == "AGARI" and is_tsumo and phase < 4 \
+                        and phase == target_winner:
+                    # Self-draw win: select Tsumo from the action phase.
+                    idx = t.get_selection_from_action_basetile(
+                        pm.BaseAction.Tsumo, [], False,
+                    )
+                    if idx >= 0:
+                        t.make_selection(idx)
+                        continue
+                if tag == "AGARI" and not is_tsumo and phase >= 4 \
+                        and t.who_make_selection() == target_winner:
+                    # Ron: winner's response phase — pick Ron.
+                    idx = t.get_selection_from_action_basetile(
+                        pm.BaseAction.Ron, [], False,
+                    )
+                    if idx >= 0:
+                        t.make_selection(idx)
+                        continue
                 actions = (t.get_self_actions() if phase < 4
                            else t.get_response_actions())
                 if len(actions) <= 1:
@@ -764,6 +798,8 @@ def _replay_one_hand_from_xml(
                     )
                     if idx >= 0:
                         t.make_selection(idx)
+                    else:
+                        t.make_selection(0)
                 else:
                     # Response phase with options but no XML naru — pass.
                     t.make_selection(0)
@@ -773,7 +809,17 @@ def _replay_one_hand_from_xml(
             recorded_finals = [
                 sc_parts[2 * i] * 100 + recorded_changes[i] for i in range(4)
             ]
-            actual_finals = list(t.get_scores())
+            # Use the engine's per-hand ``result.score`` (post-payout)
+            # as ground truth.  ``t.get_scores()`` reflects only the
+            # ``players[i].score`` field, which is updated for riichi
+            # stick deductions but NOT for AGARI payouts (see
+            # ``Mahjong/Table.cpp``), so it would falsely fail this
+            # comparison for any winning hand.
+            res = t.gamelog.result
+            if int(res.result_type) >= 0:
+                actual_finals = [int(s) for s in res.score]
+            else:
+                actual_finals = list(t.get_scores())
             if recorded_finals != actual_finals:
                 if verbose:
                     print(f"[replay] score mismatch: rec={recorded_finals} "

--- a/pymahjong/paipu_recorder.py
+++ b/pymahjong/paipu_recorder.py
@@ -535,7 +535,17 @@ class TenhouPaipuRecorder:
         # ----- Agari -----
         if rt in (pm.ResultType.RonAgari, pm.ResultType.TsumoAgari):
             winner = result.winner[0]
-            from_who = result.loser[0] if list(result.loser) else winner
+            # Distinguish ron vs tsumo via ``result_type`` rather than via
+            # ``result.loser``: the engine populates ``result.loser`` with
+            # *all three* non-winners on tsumo (see
+            # Mahjong/GameResult.cpp:233), so the previous heuristic
+            # ``loser[0] if loser else winner`` picked an arbitrary
+            # non-winner and wrote a misleading ``fromWho``.
+            is_tsumo = (rt == pm.ResultType.TsumoAgari)
+            if is_tsumo:
+                from_who = winner
+            else:
+                from_who = result.loser[0] if list(result.loser) else winner
             counter = result.results[winner]
             attrs = {
                 "who": str(winner),
@@ -555,6 +565,14 @@ class TenhouPaipuRecorder:
                     str(t.id) for t in table.dora_indicator
                 ),
             }
+            # For non-dealer tsumo, ``score1`` is what the dealer pays
+            # and ``score2`` is what each non-dealer pays.  The Tenhou
+            # display format needs both (``X-Y点`` = kodomo-pay /
+            # oya-pay), so expose ``score2`` as a side attribute.
+            # Dealer tsumo has ``score2 == 0`` (everyone pays
+            # ``score1``).  For ron, ``score2`` is meaningless.
+            if is_tsumo and int(counter.score2) > 0:
+                attrs["score2"] = str(int(counter.score2))
             return ET.Element("AGARI", attrs)
 
         # ----- Ryuukyoku (or any other terminal we treat as draw) -----

--- a/pymahjong/paipu_tenhou_json.py
+++ b/pymahjong/paipu_tenhou_json.py
@@ -471,35 +471,209 @@ def _emit_agari_json(
     el: ET.Element,
     events: Sequence[ET.Element],
 ) -> None:
-    """Translate an <AGARI> element into the result slot (index 16)."""
+    """Translate an <AGARI> element into the result slot (index 16).
+
+    Tenhou's paipu editor (``/5/1129.js``) parses the agari sub-array as
+    ``[who, from_who, pao_who, "<点>点 description string",
+      "<yaku>(<N>飜)", ...]`` — i.e. position [3] onwards must be
+    *strings*, not raw integers (the regex at offset 23546 of the
+    editor JS matches ``/[\\d\\-]+点∀?(\\d枚∀?)?/`` against position 3).
+    Emitting raw ints makes the editor's per-hand renderer throw and
+    leaves the paipu unrenderable.
+    """
     who = int(el.get("who"))
     from_who = int(el.get("fromWho"))
     sc_parts = [int(x) for x in el.get("sc", "0,0,0,0,0,0,0,0").split(",")]
     score_changes = [sc_parts[2 * i + 1] for i in range(4)]
-    ten_str = el.get("ten", "0,0,0")
-    yaku_str = el.get("yaku", "")
-    # ten_info: [fu, base_score, mangan_level]
-    ten_info = [int(x) for x in ten_str.split(",")]
-    yaku_pairs: List[int] = []
-    if yaku_str:
-        for tok in yaku_str.split(","):
-            try:
-                yaku_pairs.append(int(tok))
-            except ValueError:
-                pass
-    # Tenhou format: ["和了", [score_changes], [who, from, pao, fu, points, yaku_strings...]]
-    # The exact length of the agari sub-array varies by viewer; the
-    # minimal form ["和了", deltas, [who, from, who]] is widely accepted.
+    ten_str_raw = el.get("ten", "0,0,0")
+    yaku_str_raw = el.get("yaku", "")
+    fu, base_points, mangan_level = [int(x) for x in ten_str_raw.split(",")]
+
+    # Parse yaku list (XML emits ``id,han,id,han,...``); aggregate dora
+    # variants by count since each dora hit is reported as a separate
+    # ``Dora,1`` / ``Akadora,1`` / ``Uradora,1`` entry.
+    yaku_ids: List[int] = []
+    if yaku_str_raw:
+        tokens = [int(t) for t in yaku_str_raw.split(",") if t]
+        for i in range(0, len(tokens), 2):
+            yaku_ids.append(tokens[i])
+
+    # ten_str: position 3 of the winner sub-array — a string the editor
+    # displays verbatim (and uses to detect tsumo via "∀" suffix).
+    is_tsumo = (who == from_who)
+    total_han = _yaku_total_han(yaku_ids)
+    ten_str = _format_ten_string(
+        fu=fu,
+        han=total_han,
+        base_points=base_points,
+        mangan_level=mangan_level,
+        is_tsumo=is_tsumo,
+    )
+    yaku_strings = _format_yaku_strings(yaku_ids)
+
+    # Pao (sekinin-barai): not currently exposed via the AGARI element,
+    # so default to ``who`` (no separate liability) — Tenhou treats
+    # ``pao == who`` as "no pao".
+    winner_tuple: List[Any] = [who, from_who, who, ten_str] + yaku_strings
+
     if hand_json[16] and hand_json[16][0] == "和了":
         # Double ron — append a second [who, from, who, ten, yaku] tuple.
         hand_json[16][1] = [hand_json[16][1][i] + score_changes[i] for i in range(4)]
-        hand_json[16].append([who, from_who, who] + list(ten_info) + yaku_pairs)
+        hand_json[16].append(winner_tuple)
     else:
         hand_json[16] = [
             "和了",
             score_changes,
-            [who, from_who, who] + list(ten_info) + yaku_pairs,
+            winner_tuple,
         ]
+
+
+# Yaku id → (japanese display name, default han value).  Indexed against
+# the ``Yaku`` enum order in ``Mahjong/Yaku.h`` (None=0).  Sentinel
+# entries (Yaku_1_han, Yaku_2_han, ...) are kept so int(Yaku::X) lines up.
+_YAKU_TABLE: List[Optional["tuple[str, int]"]] = [
+    None,                       # 0: None
+    ("立直", 1),                # 1: Riichi
+    ("断幺九", 1),              # 2: Tanyao
+    ("門前清自摸和", 1),        # 3: Menzentsumo
+    ("自風 東", 1),             # 4: Jikaze_Ton
+    ("自風 南", 1),             # 5: Jikaze_Nan
+    ("自風 西", 1),             # 6: Jikaze_Sha
+    ("自風 北", 1),             # 7: Jikaze_Pei
+    ("場風 東", 1),             # 8: Bakaze_Ton
+    ("場風 南", 1),             # 9: Bakaze_Nan
+    ("場風 西", 1),             # 10: Bakaze_Sha
+    ("場風 北", 1),             # 11: Bakaze_Pei
+    ("役牌 白", 1),             # 12: Yakuhai_Haku
+    ("役牌 發", 1),             # 13: Yakuhai_Hatsu
+    ("役牌 中", 1),             # 14: Yakuhai_Chu
+    ("平和", 1),                # 15: Pinfu
+    ("一盃口", 1),              # 16: Ippeikou
+    ("槍槓", 1),                # 17: Chankan
+    ("嶺上開花", 1),            # 18: Rinshankaihou
+    ("海底摸月", 1),            # 19: Haiteiraoyue
+    ("河底撈魚", 1),            # 20: Houteiraoyu
+    ("一発", 1),                # 21: Ippatsu
+    ("ドラ", 1),                # 22: Dora (per-tile; aggregated by count)
+    ("裏ドラ", 1),              # 23: Uradora (per-tile; aggregated)
+    ("赤ドラ", 1),              # 24: Akadora (per-tile; aggregated)
+    ("北ドラ", 1),              # 25: Peidora (3-player only)
+    ("混全帯幺九", 1),          # 26: Honchantaiyaochu_Naki
+    ("一気通貫", 1),            # 27: Ikkitsuukan_Naki
+    ("三色同順", 1),            # 28: Sanshokudoujun_Naki
+    None,                       # 29: Yaku_1_han (sentinel)
+    ("両立直", 2),              # 30: Dabururiichi
+    ("三色同刻", 2),            # 31: Sanshokudoukou
+    ("三槓子", 2),              # 32: Sankantsu
+    ("対々和", 2),              # 33: Toitoiho
+    ("三暗刻", 2),              # 34: Sanankou
+    ("小三元", 2),              # 35: Shousangen
+    ("混老頭", 2),              # 36: Honroutou
+    ("七対子", 2),              # 37: Chiitoitsu
+    ("混全帯幺九", 2),          # 38: Honchantaiyaochu
+    ("一気通貫", 2),            # 39: Ikkitsuukan
+    ("三色同順", 2),            # 40: Sanshokudoujun
+    ("純全帯幺九", 2),          # 41: Junchantaiyaochu_Naki
+    ("混一色", 2),              # 42: Honitsu_Naki
+    None,                       # 43: Yaku_2_han (sentinel)
+    ("二盃口", 3),              # 44: Rianpeikou
+    ("純全帯幺九", 3),          # 45: Junchantaiyaochu
+    ("混一色", 3),              # 46: Honitsu
+    None,                       # 47: Yaku_3_han
+    ("清一色", 5),              # 48: Chinitsu_Naki
+    None,                       # 49: Yaku_5_han
+    ("清一色", 6),              # 50: Chinitsu
+    None,                       # 51: Yaku_6_han
+    ("流し満貫", 5),            # 52: Nagashimangan
+    None,                       # 53: Yaku_mangan (sentinel)
+    ("天和", 13),               # 54: Tenhou
+    ("地和", 13),               # 55: Chihou
+    ("大三元", 13),             # 56: Daisangen
+    ("四暗刻", 13),             # 57: Siiankou
+    ("字一色", 13),             # 58: Tsuiisou
+    ("緑一色", 13),             # 59: Ryuiisou
+    ("清老頭", 13),             # 60: Chinroutou
+    ("国士無双", 13),           # 61: Kokushimusou
+    ("小四喜", 13),             # 62: Shousuushi
+    ("四槓子", 13),             # 63: Siikantsu
+    ("九蓮宝燈", 13),           # 64: Chuurenpoutou
+    None,                       # 65: Yakuman (sentinel)
+    ("四暗刻単騎", 26),         # 66: Siiankou_1 (double yakuman)
+    ("国士無双十三面", 26),     # 67: Koukushimusou_13
+    ("純正九蓮宝燈", 26),       # 68: Chuurenpoutou_9
+    ("大四喜", 26),             # 69: Daisuushi
+]
+_DORA_IDS = {22, 23, 24, 25}  # Dora / Uradora / Akadora / Peidora
+
+
+def _yaku_total_han(yaku_ids: Sequence[int]) -> int:
+    """Sum the default-han values for the given yaku id sequence."""
+    total = 0
+    for yid in yaku_ids:
+        if 0 <= yid < len(_YAKU_TABLE) and _YAKU_TABLE[yid] is not None:
+            total += _YAKU_TABLE[yid][1]
+    return total
+
+
+def _format_yaku_strings(yaku_ids: Sequence[int]) -> List[str]:
+    """Format yaku list as Tenhou-editor display strings.
+
+    Each entry is ``"<name>(<N>飜)"`` for normal yaku, ``"<name>(役満)"``
+    for yakuman, or ``"<name>(W役満)"`` for double-yakuman.  Dora-class
+    yaku (Dora/Uradora/Akadora/Peidora) are aggregated by count.
+    """
+    out: List[str] = []
+    seen_dora: Dict[int, int] = {}  # yaku_id -> count
+    for yid in yaku_ids:
+        if yid in _DORA_IDS:
+            seen_dora[yid] = seen_dora.get(yid, 0) + 1
+            continue
+        if not (0 <= yid < len(_YAKU_TABLE)) or _YAKU_TABLE[yid] is None:
+            continue
+        name, han = _YAKU_TABLE[yid]
+        if han >= 26:
+            out.append(f"{name}(W役満)")
+        elif han >= 13:
+            out.append(f"{name}(役満)")
+        else:
+            out.append(f"{name}({han}飜)")
+    for yid, count in seen_dora.items():
+        name = _YAKU_TABLE[yid][0]
+        out.append(f"{name}({count}飜)")
+    return out
+
+
+def _format_ten_string(
+    *,
+    fu: int,
+    han: int,
+    base_points: int,
+    mangan_level: int,
+    is_tsumo: bool,
+) -> str:
+    """Build the ``n[3]`` ten-display string for the agari sub-array.
+
+    Tenhou's regex requires the string to contain ``<digits>点`` (with
+    optional ``∀`` for tsumo).  Format depends on mangan tier:
+
+    * 0 — non-mangan: ``"<fu>符<han>飜<points>点"``
+    * 1 — mangan: ``"満貫<points>点"``
+    * 2 — haneman: ``"跳満<points>点"``
+    * 3 — baiman: ``"倍満<points>点"``
+    * 4 — sanbaiman: ``"三倍満<points>点"``
+    * 5+ — yakuman: ``"役満<points>点"``
+    """
+    suffix = "∀" if is_tsumo else ""
+    if mangan_level <= 0:
+        han_disp = max(han, 1)
+        return f"{fu}符{han_disp}飜{base_points}点{suffix}"
+    name = {
+        1: "満貫",
+        2: "跳満",
+        3: "倍満",
+        4: "三倍満",
+    }.get(mangan_level, "役満")
+    return f"{name}{base_points}点{suffix}"
 
 
 def _emit_ryuukyoku_json(hand_json: List[Any], el: ET.Element) -> None:

--- a/pymahjong/paipu_tenhou_json.py
+++ b/pymahjong/paipu_tenhou_json.py
@@ -350,7 +350,7 @@ def _translate_hand(init: ET.Element, events: Sequence[ET.Element]) -> List[Any]
             continue
 
         if tag == "AGARI":
-            _emit_agari_json(hand_json, ev, events)
+            _emit_agari_json(hand_json, ev, events, oya=int(init.get("oya", "0")))
             continue
 
         if tag == "RYUUKYOKU":
@@ -470,6 +470,8 @@ def _emit_agari_json(
     hand_json: List[Any],
     el: ET.Element,
     events: Sequence[ET.Element],
+    *,
+    oya: int = 0,
 ) -> None:
     """Translate an <AGARI> element into the result slot (index 16).
 
@@ -488,6 +490,11 @@ def _emit_agari_json(
     ten_str_raw = el.get("ten", "0,0,0")
     yaku_str_raw = el.get("yaku", "")
     fu, base_points, mangan_level = [int(x) for x in ten_str_raw.split(",")]
+    # Side attribute populated by the recorder for non-dealer tsumo:
+    # ``score2`` = per-non-dealer pay (Tenhou displays "X-Y点" =
+    # kodomo-pay/oya-pay).  Missing / 0 = not applicable (ron, or
+    # dealer tsumo where everyone pays ``score1``).
+    score2 = int(el.get("score2", "0"))
 
     # Parse yaku list (XML emits ``id,han,id,han,...``); aggregate dora
     # variants by count since each dora hit is reported as a separate
@@ -501,13 +508,16 @@ def _emit_agari_json(
     # ten_str: position 3 of the winner sub-array — a string the editor
     # displays verbatim (and uses to detect tsumo via "∀" suffix).
     is_tsumo = (who == from_who)
+    is_oya = (who == oya)
     total_han = _yaku_total_han(yaku_ids)
     ten_str = _format_ten_string(
         fu=fu,
         han=total_han,
-        base_points=base_points,
+        score1=base_points,
+        score2=score2,
         mangan_level=mangan_level,
         is_tsumo=is_tsumo,
+        is_oya=is_oya,
     )
     yaku_strings = _format_yaku_strings(yaku_ids)
 
@@ -647,33 +657,57 @@ def _format_ten_string(
     *,
     fu: int,
     han: int,
-    base_points: int,
+    score1: int,
+    score2: int,
     mangan_level: int,
     is_tsumo: bool,
+    is_oya: bool,
 ) -> str:
     """Build the ``n[3]`` ten-display string for the agari sub-array.
 
     Tenhou's regex requires the string to contain ``<digits>点`` (with
-    optional ``∀`` for tsumo).  Format depends on mangan tier:
+    optional ``∀`` for dealer tsumo or ``X-Y点`` for non-dealer tsumo).
 
-    * 0 — non-mangan: ``"<fu>符<han>飜<points>点"``
-    * 1 — mangan: ``"満貫<points>点"``
-    * 2 — haneman: ``"跳満<points>点"``
-    * 3 — baiman: ``"倍満<points>点"``
-    * 4 — sanbaiman: ``"三倍満<points>点"``
-    * 5+ — yakuman: ``"役満<points>点"``
+    Point-encoding cases:
+
+    * **Ron** (``not is_tsumo``): ``score1`` is the *total* point
+      transfer from the loser → ``"...{score1}点"``.
+    * **Dealer tsumo** (``is_oya and is_tsumo``): ``score1`` is what
+      each non-dealer pays → ``"...{score1}点∀"`` (``∀`` = "from all").
+    * **Non-dealer tsumo** (``not is_oya and is_tsumo``): ``score1`` is
+      what the dealer pays, ``score2`` is what each other non-dealer
+      pays → ``"...{score2}-{score1}点"`` (kodomo-pay/oya-pay).
+
+    Mangan-tier names (満貫/跳満/倍満/三倍満/役満) replace the
+    ``<fu>符<han>飜`` prefix when ``mangan_level > 0``.
     """
-    suffix = "∀" if is_tsumo else ""
-    if mangan_level <= 0:
+    # Build the prefix (fu/han block or mangan-tier name).
+    if mangan_level > 0:
+        prefix = {
+            1: "満貫",
+            2: "跳満",
+            3: "倍満",
+            4: "三倍満",
+        }.get(mangan_level, "役満")
+    else:
         han_disp = max(han, 1)
-        return f"{fu}符{han_disp}飜{base_points}点{suffix}"
-    name = {
-        1: "満貫",
-        2: "跳満",
-        3: "倍満",
-        4: "三倍満",
-    }.get(mangan_level, "役満")
-    return f"{name}{base_points}点{suffix}"
+        prefix = f"{fu}符{han_disp}飜"
+
+    # Build the points body and tsumo marker.
+    if not is_tsumo:
+        body = f"{score1}点"
+    elif is_oya:
+        body = f"{score1}点∀"
+    else:
+        # Non-dealer tsumo: ``X-Y点`` where X = each kodomo pay
+        # (``score2``), Y = oya pay (``score1``).  If the recorder
+        # didn't expose ``score2`` (legacy XMLs), fall back to a
+        # single-value display so the Tenhou regex still matches.
+        if score2 > 0:
+            body = f"{score2}-{score1}点"
+        else:
+            body = f"{score1}点∀"
+    return prefix + body
 
 
 def _emit_ryuukyoku_json(hand_json: List[Any], el: ET.Element) -> None:

--- a/test/test_paipu_recorder.py
+++ b/test/test_paipu_recorder.py
@@ -77,3 +77,94 @@ def test_record_minimum_metadata(tmp_path):
 def test_n_hands_count(tmp_path):
     recorder, n = _random_selfplay_record(3, base_seed=3000)
     assert recorder.n_hands == n
+
+
+def test_agari_score_changes_match_engine(tmp_path):
+    """Recorded ``<AGARI sc=...>`` deltas must reflect the engine's
+    post-payout per-hand scores (``result.score``), not the pre-payout
+    snapshot from ``table.get_scores()`` which only tracks
+    ``players[i].score`` (= initial − riichi stick).
+
+    Regression for the bug that produced empty / wrong score deltas
+    (e.g. ``sc="...,0,...,0,...,0,...,0"`` for a 7700-point ron) and
+    made the resulting Tenhou-editor URLs unrenderable.
+    """
+    import xml.etree.ElementTree as ET
+
+    # Synthesize an agari by replaying a deterministic seed that lands
+    # in an AGARI under the engine's default dealing.  We probe a small
+    # range of seeds and take the first that wins; random uniform play
+    # alone almost never produces agari (≈3% per hand) so we use a
+    # greedy heuristic: never call chi/pon/kan/riichi, always tsumo / ron
+    # / discard the rightmost tile.  This still relies on the dealt
+    # tiles but converges to AGARI much faster than uniform random.
+    def _greedy_to_agari(env, base_seed: int, *, n_tries: int = 200) -> int:
+        for off in range(n_tries):
+            seed = base_seed + off
+            env.reset(seed=seed)
+            steps = 0
+            while not env.is_over() and steps < 500:
+                pid = env.get_curr_player_id()
+                valid = np.flatnonzero(env.get_valid_actions(nhot=True))
+                if len(valid) == 0:
+                    break
+                # Action layout (see env_pymahjong.py): 0-33 discard,
+                # 34 riichi, 35 chi(L)..37 chi(R), 38 pon, 39 ankan,
+                # 40 minkan, 41 kakan, 42 tsumo, 43 ron, 44 push, 45 pass.
+                # Prefer tsumo > ron > pass > smallest discard > anything.
+                pref = []
+                if 42 in valid:
+                    pref.append(42)
+                elif 43 in valid:
+                    pref.append(43)
+                else:
+                    discards = [a for a in valid.tolist() if a < 34]
+                    if discards:
+                        pref.append(min(discards))
+                    elif 45 in valid:
+                        pref.append(45)
+                    else:
+                        pref.append(int(valid[0]))
+                env.step(pid, pref[0])
+                steps += 1
+            if int(env.t.get_phase()) == int(pm.PhaseEnum.GAME_OVER):
+                res = env.t.gamelog.result
+                if int(res.result_type) in (
+                    int(pm.ResultType.RonAgari),
+                    int(pm.ResultType.TsumoAgari),
+                ):
+                    return seed
+        return -1
+
+    env = MahjongEnv()
+    seed = _greedy_to_agari(env, 4200)
+    assert seed >= 0, "could not synthesize an AGARI hand in 200 tries"
+
+    rec = TenhouPaipuRecorder()
+    rec.record_hand(env.t, seed=seed)
+    root = ET.fromstring(rec.to_string())
+    agari = root.find("AGARI")
+    assert agari is not None, "expected an AGARI element"
+
+    sc = [int(x) for x in agari.get("sc").split(",")]
+    deltas = sc[1::2]
+    # Chip conservation: deltas must sum to zero.
+    assert sum(deltas) == 0, f"AGARI sc deltas don't sum to zero: {deltas}"
+
+    # The winner's recorded delta must be > 0 for any non-zero-point
+    # agari (no triple-overlap edge case here since we only kept one).
+    ten = agari.get("ten")
+    pts = int(ten.split(",")[1])
+    who = int(agari.get("who"))
+    assert pts > 0, f"unexpected zero-point agari (ten={ten})"
+    assert deltas[who] > 0, (
+        f"winner {who} has non-positive delta {deltas[who]} for "
+        f"an agari worth {pts} points (sc={sc})"
+    )
+
+    # Replay must validate against the recorded paipu now that both
+    # recorder and validator agree on ``result.score`` as ground truth.
+    out = tmp_path / "agari_one.xml"
+    rec.save(str(out))
+    n_ok, n_fail = replay_recorded_paipu(str(out), verbose=False)
+    assert (n_ok, n_fail) == (1, 0)

--- a/test/test_paipu_recorder.py
+++ b/test/test_paipu_recorder.py
@@ -168,3 +168,73 @@ def test_agari_score_changes_match_engine(tmp_path):
     rec.save(str(out))
     n_ok, n_fail = replay_recorded_paipu(str(out), verbose=False)
     assert (n_ok, n_fail) == (1, 0)
+
+
+def test_agari_from_who_matches_ron_tsumo_semantics(tmp_path):
+    """``<AGARI fromWho=...>`` must equal ``who`` for tsumo and a real
+    discarder for ron.
+
+    Regression for the bug where the recorder used the heuristic
+    ``from_who = result.loser[0] if loser else winner`` — but
+    ``GameResult.cpp`` populates ``result.loser`` with *all three*
+    non-winners on tsumo, so the heuristic wrote a meaningless
+    ``fromWho`` (an arbitrary non-winner) for tsumo wins.
+    """
+    import xml.etree.ElementTree as ET
+    import random
+
+    env = MahjongEnv()
+    rng = random.Random(0)
+    n_ron_checked = 0
+    n_tsumo_checked = 0
+    # Tsumo wins are rare under random / greedy play; scan a wide seed
+    # range and check every agari hand we encounter.
+    for seed in range(7000, 7500):
+        env.reset(seed=seed)
+        steps = 0
+        while not env.is_over() and steps < 500:
+            pid = env.get_curr_player_id()
+            valid = np.flatnonzero(env.get_valid_actions(nhot=True))
+            if len(valid) == 0:
+                break
+            v = valid.tolist()
+            if 42 in v:
+                a = 42
+            elif 43 in v:
+                a = 43
+            else:
+                d = [x for x in v if x < 34]
+                a = min(d) if d else (45 if 45 in v else int(rng.choice(v)))
+            env.step(pid, a)
+            steps += 1
+        if int(env.t.get_phase()) != int(pm.PhaseEnum.GAME_OVER):
+            continue
+        res = env.t.gamelog.result
+        rt = int(res.result_type)
+        if rt not in (int(pm.ResultType.RonAgari), int(pm.ResultType.TsumoAgari)):
+            continue
+        rec = TenhouPaipuRecorder()
+        rec.record_hand(env.t, seed=seed)
+        root = ET.fromstring(rec.to_string())
+        ag = root.find("AGARI")
+        who = int(ag.get("who"))
+        from_who = int(ag.get("fromWho"))
+        if rt == int(pm.ResultType.TsumoAgari):
+            n_tsumo_checked += 1
+            assert from_who == who, (
+                f"tsumo AGARI must have fromWho == who; "
+                f"got who={who} fromWho={from_who} (seed={seed})"
+            )
+        else:
+            n_ron_checked += 1
+            assert from_who != who, (
+                f"ron AGARI must have fromWho != who; "
+                f"got who={who} fromWho={from_who} (seed={seed})"
+            )
+        if n_ron_checked >= 5 and n_tsumo_checked >= 0:
+            break
+    # We expect to see at least one ron in 500 seeds; tsumo coverage
+    # is best-effort (statistically uncommon for random play).
+    assert n_ron_checked >= 1, (
+        f"didn't observe any ron in 500 seeds — test ineffective"
+    )

--- a/test/test_paipu_tenhou_json.py
+++ b/test/test_paipu_tenhou_json.py
@@ -116,3 +116,83 @@ def test_xml_string_variant_matches_path(tmp_path):
     a = xml_to_tenhou_json(str(xml_path))
     b = xml_string_to_tenhou_json(text)
     assert a == b
+
+
+def test_agari_subarray_uses_tenhou_string_format(tmp_path):
+    """Regression: AGARI winner sub-array must follow Tenhou's expected
+    schema ``[who, from, pao, "<点>点 string", "<yaku>(<N>飜)", ...]``.
+
+    The Tenhou paipu editor (``/5/1129.js``) calls ``h[3].match(...)``
+    on the winner sub-array's position-3 entry — if it's a raw int
+    (the previous bug) JS throws ``h[3].match is not a function`` and
+    the page hangs on "L O A D I N G ...".  This test directly checks
+    the schema so any future regression is caught at unit-test time.
+    """
+    # Synthesize one agari hand deterministically using a greedy
+    # heuristic (random play almost never wins).
+    env = MahjongEnv()
+    seed = -1
+    for off in range(200):
+        s = 6500 + off
+        env.reset(seed=s)
+        steps = 0
+        while not env.is_over() and steps < 500:
+            pid = env.get_curr_player_id()
+            valid = np.flatnonzero(env.get_valid_actions(nhot=True))
+            if len(valid) == 0:
+                break
+            v = valid.tolist()
+            if 42 in v:
+                a = 42  # tsumo
+            elif 43 in v:
+                a = 43  # ron
+            else:
+                d = [x for x in v if x < 34]
+                a = min(d) if d else (45 if 45 in v else int(v[0]))
+            env.step(pid, a)
+            steps += 1
+        if int(env.t.get_phase()) == int(pm.PhaseEnum.GAME_OVER):
+            res = env.t.gamelog.result
+            if int(res.result_type) in (
+                int(pm.ResultType.RonAgari),
+                int(pm.ResultType.TsumoAgari),
+            ):
+                seed = s
+                break
+    assert seed >= 0, "could not synthesize an AGARI hand in 200 tries"
+
+    rec = TenhouPaipuRecorder()
+    rec.record_hand(env.t, seed=seed)
+    out = tmp_path / "agari.xml"
+    rec.save(str(out))
+
+    data = xml_to_tenhou_json(str(out))
+    hand = data["log"][0]
+    result = hand[16]
+    assert result[0] == "和了", f"expected agari result, got {result[0]!r}"
+    winner_tuple = result[2]
+    # Schema: [who:int, from:int, pao:int, ten_str:str, *yaku_str:str]
+    assert len(winner_tuple) >= 5, (
+        f"winner_tuple too short: {winner_tuple}"
+    )
+    assert isinstance(winner_tuple[0], int)
+    assert isinstance(winner_tuple[1], int)
+    assert isinstance(winner_tuple[2], int)
+    assert isinstance(winner_tuple[3], str), (
+        f"ten_str at position 3 must be str (was {type(winner_tuple[3]).__name__}); "
+        f"Tenhou JS calls .match() on it"
+    )
+    # Tenhou regex: /[\d\-]+点∀?(\d枚∀?)?/
+    import re
+    assert re.search(r"[\d\-]+点", winner_tuple[3]), (
+        f"ten_str doesn't match Tenhou regex: {winner_tuple[3]!r}"
+    )
+    # Yaku entries: strings matching /^([^\(]*)\((\d+飜|)(?:役満)?(\d+枚|)\)/
+    yaku_re = re.compile(r"^([^\(]*)\((\d+飜|)(?:役満)?(\d+枚|)\)")
+    for i, yaku in enumerate(winner_tuple[4:], start=4):
+        assert isinstance(yaku, str), (
+            f"yaku at position {i} must be str (was {type(yaku).__name__})"
+        )
+        assert yaku_re.match(yaku), (
+            f"yaku string doesn't match Tenhou regex: {yaku!r}"
+        )

--- a/test/test_paipu_tenhou_json.py
+++ b/test/test_paipu_tenhou_json.py
@@ -196,3 +196,107 @@ def test_agari_subarray_uses_tenhou_string_format(tmp_path):
         assert yaku_re.match(yaku), (
             f"yaku string doesn't match Tenhou regex: {yaku!r}"
         )
+
+
+# --- Ron / Tsumo classification ---
+# These tests bypass the engine and feed synthetic <AGARI> XML directly
+# to the converter so we can exercise tsumo-oya, tsumo-kodomo, and ron
+# code paths without having to coax the engine into producing each
+# variant under random self-play (tsumo wins are extremely rare).
+
+import xml.etree.ElementTree as ET  # noqa: E402
+
+from pymahjong.paipu_tenhou_json import xml_string_to_tenhou_json  # noqa: E402
+
+_BASE_INIT = (
+    '<mjloggm ver="2.3">'
+    '<GO type="33" lobby="0"/>'
+    '<UN n0="A" n1="B" n2="C" n3="D" dan="0,0,0,0" '
+    'rate="1500,1500,1500,1500" sx="C,C,C,C"/>'
+    '<TAIKYOKU oya="{oya}"/>'
+    '<INIT seed="0,0,0,0,0,0" ten="250,250,250,250" oya="{oya}" '
+    'hai0="0,1,2,3,4,5,6,7,8,9,10,11,12" '
+    'hai1="16,17,18,19,20,21,22,23,24,25,26,27,28" '
+    'hai2="32,33,34,35,36,37,38,39,40,41,42,43,44" '
+    'hai3="48,49,50,51,52,53,54,55,56,57,58,59,60" '
+    'seed_int="0"/>'
+)
+
+
+def _agari_xml(*, who, fromWho, oya, sc, ten, yaku="", score2=None):
+    score2_attr = f' score2="{score2}"' if score2 is not None else ""
+    return (
+        _BASE_INIT.format(oya=oya)
+        + f'<AGARI who="{who}" fromWho="{fromWho}" ba="0,0" sc="{sc}" '
+        f'hai="0,1,2,3,4,5,6,7,8,9,10,11,12,13" machi="13" '
+        f'ten="{ten}" yaku="{yaku}" doraHai="0"{score2_attr}/>'
+        + "</mjloggm>"
+    )
+
+
+def test_ron_ten_string_format():
+    """Ron: ten string is '<fu>符<han>飜<total>点' (no ∀, no X-Y)."""
+    # P2 (kodomo) ron P0 (oya), 40fu 3han = 5200pts total.
+    xml = _agari_xml(
+        who=2, fromWho=0, oya=0,
+        sc="250,-52,250,0,250,52,250,0",
+        ten="40,5200,0",
+        yaku="1,1,2,1,3,1",  # riichi(1) + tanyao(1) + tsumo(1) → 3 han total
+    )
+    data = xml_string_to_tenhou_json(xml)
+    ten_str = data["log"][0][16][2][3]
+    assert ten_str == "40符3飜5200点", f"got {ten_str!r}"
+    assert "∀" not in ten_str
+    assert "-" not in ten_str.replace("点", "")  # no X-Y form
+
+
+def test_dealer_tsumo_ten_string_format():
+    """Dealer tsumo: ten string ends with '点∀' (everyone pays score1)."""
+    # P0 (oya) tsumo, 30fu 2han, score1=1000 (each non-dealer pays 1000).
+    # fromWho == who is the tsumo marker.
+    xml = _agari_xml(
+        who=0, fromWho=0, oya=0,
+        sc="250,30,250,-10,250,-10,250,-10",
+        ten="30,1000,0",
+        yaku="1,1,3,1",
+    )
+    data = xml_string_to_tenhou_json(xml)
+    ten_str = data["log"][0][16][2][3]
+    assert ten_str == "30符2飜1000点∀", f"got {ten_str!r}"
+
+
+def test_nondealer_tsumo_ten_string_format():
+    """Non-dealer tsumo: ten string is '<fu>符<han>飜<X>-<Y>点'
+    (X = each kodomo pay = score2, Y = oya pay = score1)."""
+    # P1 (kodomo) tsumo with oya=P0, 30fu 2han.  score1=1000 (P0 pays),
+    # score2=500 (P2/P3 each pay).
+    xml = _agari_xml(
+        who=1, fromWho=1, oya=0,
+        sc="250,-10,250,20,250,-5,250,-5",
+        ten="30,1000,0",
+        yaku="1,1,3,1",
+        score2=500,
+    )
+    data = xml_string_to_tenhou_json(xml)
+    ten_str = data["log"][0][16][2][3]
+    assert ten_str == "30符2飜500-1000点", f"got {ten_str!r}"
+
+
+def test_tsumo_winner_tuple_from_equals_who():
+    """Tsumo: winner_tuple[1] (fromWho) must equal winner_tuple[0] (who).
+
+    This is the canonical Tenhou convention for tsumo (the editor's
+    quick-summary logic at offset 23546 uses ``b[2][0]==b[2][1]`` to
+    detect tsumo vs ron)."""
+    xml = _agari_xml(
+        who=2, fromWho=2, oya=0,
+        sc="250,-10,250,-10,250,30,250,-10",
+        ten="30,1000,0",
+        yaku="3,1",
+        score2=0,  # dealer-tsumo style: omit or 0 means everyone pays score1
+    )
+    data = xml_string_to_tenhou_json(xml)
+    winner_tuple = data["log"][0][16][2]
+    assert winner_tuple[0] == winner_tuple[1] == 2, (
+        f"tsumo winner_tuple must have who==fromWho, got {winner_tuple}"
+    )


### PR DESCRIPTION
## Problem
Recorded Tenhou paipu URLs (from `record_one_selfplay_hand`, used by BC self-play evaluation) were unrenderable in the official Tenhou paipu editor.

Three coupled bugs uncovered in sequence — each one's fix exposed the next.

### Bug 1 — Wrong score deltas (`paipu_recorder.py`)
`Mahjong/Table.cpp` only mutates `players[i].score` for game-init and riichi-stick deductions. AGARI payouts are written exclusively to `result.score[i]` (`GameResult.cpp`) and never back-propagated. The recorder was computing per-hand deltas via `table.get_scores() - gl.start_scores`, which in single-hand termination contexts (e.g. `V4MultiAgentEnv`) misses the entire agari payout.

### Bug 2 — Malformed AGARI JSON (`paipu_tenhou_json.py`)
Browser-confirmed via headless Chromium:
```
pageerror: h[3].match is not a function
```
Tenhou's editor (`/5/1129.js`) calls `h[3].match(/[\d\-]+点∀?(\d枚∀?)?/)` on position-3 of the agari winner sub-array, and `f[g].match(/^([^\(]*)\((\d+飜|)(?:役満)?(\d+枚|)\)/)` on positions 4..n. Our converter emitted raw ints (`[who, from, who, 30, 1000, 0, 1, 1, 3, 1]`) where the JS expected strings, so `.match()` threw TypeError and the page hung at "L O A D I N G ...".

### Bug 3 — Ron / tsumo misclassification (both files)
`GameResult.cpp:233` populates `result.loser` with *all three non-winners* on tsumo. The recorder's heuristic `from_who = result.loser[0] if loser else winner` therefore picked an arbitrary non-winner and wrote a misleading `fromWho` for tsumo. Tenhou's editor detects tsumo via `b[2][0] == b[2][1]` (`/5/1129.js` offset 23546), so a tsumo with `who != fromWho` was rendered as a phantom ron with wildly wrong points.

## Fix

**Commit 1 — `paipu_recorder.py` score deltas:**
* `_result_element` uses `result.score` when the result type is valid, falling back to `table.get_scores()` only for the uninitialised / Error path.
* `_replay_one_hand_from_xml` was implicitly hiding the same bug — it compared against the same broken `t.get_scores()` and never actually triggered the recorded ron/tsumo (it just passed). Now actively selects Ron / Tsumo for the recorded winner during the AGARI drain loop and validates against `t.gamelog.result.score`.
* New regression `test_agari_score_changes_match_engine`.

**Commit 2 — `paipu_tenhou_json.py` agari sub-array strings:**
* `_format_ten_string` builds proper `"<fu>符<han>飜<点>点"` (or 満貫/跳満/倍満/三倍満/役満 mangan-tier strings).
* `_format_yaku_strings` translates yaku ids to Japanese display names (table indexed against `Mahjong/Yaku.h`) and emits `"<name>(<N>飜)"` / `"<name>(役満)"` / `"<name>(W役満)"`. Dora-class yaku aggregated by count.
* New regression `test_agari_subarray_uses_tenhou_string_format` checks the schema against Tenhou's `.match()` regexes.

**Commit 3 — `paipu_recorder.py` + `paipu_tenhou_json.py` ron/tsumo:**
* Recorder dispatches on `result_type`: TsumoAgari → `fromWho = winner`; RonAgari → `fromWho = loser[0]`.
* Recorder exposes `counter.score2` (kodomo-pay for non-dealer tsumo) as a side attribute on AGARI.
* Converter's `_format_ten_string` takes `is_tsumo` + `is_oya` + `score2` and produces:
  - Ron: `"...点"` (no marker)
  - Dealer tsumo: `"...点∀"` (∀ = "from all")
  - Non-dealer tsumo: `"<score2>-<score1>点"` (kodomo-pay/oya-pay)
* New tests for ron, dealer tsumo, non-dealer tsumo, and tsumo `who==fromWho` invariant.

## Validation
* All 99 existing + new tests pass (`pytest test/`).
* End-to-end browser tests in headless Chromium:
  - **OLD URL** (`hand_001_seed99001.url.txt`): `pageerror: h[3].match is not a function` → page stuck at "L O A D I N G ..."
  - **NEW URL after commit 2**: renders ">> 牌譜を再生" (loads), but seed99001 displayed as a phantom ron with wrong points.
  - **NEW URL after commit 3**: seed99001 correctly identified as oya tsumo, ten_str=`"30符2飜1000点∀"`, page loads cleanly; seed100000 still a clean ron with `"30符4飜7700点"`.